### PR TITLE
Fix: Spelling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 </p>
 <h2 align="center">ScoutBar</h2>
 
-<p align="center">⌨️ Spolight for your app</p>
+<p align="center">⌨️ Spotlight for your app</p>
 
 <br />
 <br />
@@ -90,7 +90,7 @@ instructions on how to use them, in the documentation.
 
 #### `Default -> true`
 
-Allows you the abilty to disable / hide scoutbar tutorial hints. i'e the section
+Allows you the ability to disable / hide scoutbar tutorial hints. i'e the section
 that tells users to navigate with the arrows or tabs. e.g
 
 ```jsx
@@ -123,7 +123,7 @@ requested that the system minimize the amount of non-essential motion it uses.
 
 #### `Default -> 'light'`
 
-Allows you to switch the theme of the scoutbar depeneding on how you want it.
+Allows you to switch the theme of the scoutbar depending on how you want it.
 auto switches to the theme of the current system.
 
 ```jsx
@@ -133,17 +133,17 @@ auto switches to the theme of the current system.
   />
 ```
 
-### aknowledgement
+### acknowledgement
 
 #### `Type -> Boolean`
 
 #### `Default -> true`
 
-Show the scoutbar aknowledgemnt logo on the top right of the input bar.
+Show the scoutbar acknowledgement logo on the top right of the input bar.
 
 ```jsx
   <ScoutBar
-   aknowledgement={true}
+   acknowledgement={true}
     ...
   />
 ```
@@ -154,7 +154,7 @@ Show the scoutbar aknowledgemnt logo on the top right of the input bar.
 
 #### `Default -> #000`
 
-Allows you to set the official scoutbar brand color. it helps to matcht the
+Allows you to set the official scoutbar brand color. it helps to match the
 color grade on your application
 
 ```jsx
@@ -196,7 +196,7 @@ Reveal the scoutbar with an external action. PS forcefully opens the scoutbar
 
 ```jsx
   <ScoutBar
-revealScoutbar={// youe state hook here }
+revealScoutbar={// your state hook here }
     ...
   />
 ```

--- a/src/scoutbar/index.tsx
+++ b/src/scoutbar/index.tsx
@@ -51,10 +51,10 @@ export interface ScoutBarProps {
    */
   theme?: 'light' | 'dark' | 'auto';
   /**
-   * Aknowledge the scout bar tutorial.
+   * Acknowledge the scout bar tutorial.
    * @default true
    */
-  aknowledgement?: boolean;
+  acknowledgement?: boolean;
   /**
    * Change scoutbar brand color.
    * @default '#000'
@@ -136,7 +136,7 @@ export const defaultProps: Partial<ScoutBarProps> = {
   tutorial: true,
   noAnimation: false,
   theme: 'light',
-  aknowledgement: true,
+  acknowledgement: true,
   brandColor: '#61bb65',
   placeholder: [
     'What would you like to do today ?',
@@ -163,7 +163,7 @@ const ScoutBar: React.FC<ScoutBarProps> = ({
   tutorial,
   noAnimation,
   theme,
-  aknowledgement,
+  acknowledgement,
   brandColor,
   placeholder,
   bodyScroll,
@@ -188,7 +188,7 @@ const ScoutBar: React.FC<ScoutBarProps> = ({
 
   /**
    * Revise action data type if its a function to a an array
-   * We want to give user the ability to Item creation fucntions as a parameter in the props
+   * We want to give user the ability to Item creation functions as a parameter in the props
    *
    * e.g
    * ...
@@ -315,10 +315,10 @@ const ScoutBar: React.FC<ScoutBarProps> = ({
                     {tutorial && (
                       <ScoutTutorial
                         brandColor={brandColor}
-                        aknowledgement={aknowledgement}
+                        acknowledgement={acknowledgement}
                       />
                     )}
-                    {aknowledgement && <ScoutBarLogo brandColor={brandColor} />}
+                    {acknowledgement && <ScoutBarLogo brandColor={brandColor} />}
                   </div>
                 </div>
               </main>
@@ -333,11 +333,11 @@ const ScoutBar: React.FC<ScoutBarProps> = ({
 
 export const ScoutTutorial: React.FC<Partial<ScoutBarProps>> = ({
   brandColor,
-  aknowledgement,
+  acknowledgement,
 }) => (
   <div className="scout__bar-tutorial-section">
-    {aknowledgement && (
-      <div className="scout__bar-mobile-aknowledge">
+    {acknowledgement && (
+      <div className="scout__bar-mobile-acknowledge">
         <p>
           Powered by <ScoutBarLogo brandColor={brandColor} />
         </p>

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -141,7 +141,7 @@
     padding: 10px 20px;
     border-top: 1px solid var(--scout-light-grey);
 
-    .scout__bar-mobile-aknowledge {
+    .scout__bar-mobile-acknowledge {
       display: none;
 
       @include respond-below(sm) {


### PR DESCRIPTION
Hey @adenekan41, in this PR some spelling errors have been amended.

The files changed are the `readme`, `src/scoutbar/index.tsx` and `src/styles/index.scss`. 

I am conscious that the changing of `aknowledgement` to `acknowledgment` as a prop to ScoutBar is a breaking change, please let me know if you would like me to add in backwards compatibility for users who may currently be using the outdated spelling.

Thanks for the awesome tool and I'll definitely be helping out with some more contributions soon! 