### PR TITLE
(chore): Scoutbar v1.1.12

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "scoutbar"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -24,11 +24,11 @@
     <div class="card card-body col-md-4 m-auto mt-5">
       <h4>PS!!</h4>
       <h6>
-        This test enviroment uses
+        This test environment uses
         <a href="https://caniuse.com/import-maps" class="text-success"
           >https://caniuse.com/import-maps</a
         >
-        so make sure you are on an enviroment that supports this
+        so make sure you are on an environment that supports this
       </h6>
     </div>
 

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -1,14 +1,7 @@
 /* -------------------------------------------------------------------------- */
 /*                            External Dependencies                           */
 /* -------------------------------------------------------------------------- */
-import React, {
-  Fragment,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 /* -------------------------- Internal Dependencies ------------------------- */
 import { useScoutKey, ScoutBarProps, defaultProps } from 'index';

--- a/src/components/scout-bar-provider/index.tsx
+++ b/src/components/scout-bar-provider/index.tsx
@@ -10,6 +10,8 @@ import scoutSearch from 'helpers/scout-search';
 
 interface ScoutBarProviderProps extends Partial<ScoutBarProps> {
   values?: {
+    scoutbarReveal?: boolean;
+    setScoutbarReveal?: (value: boolean) => void;
     inputValue?: string;
     setInputValue?: (value: string) => void;
   };
@@ -21,11 +23,13 @@ const ScoutBarProvider: React.FC<ScoutBarProviderProps> = ({
   values,
 }) => {
   const [section, setSection] = useState<IScoutSectionAction | null>(null);
-  const { inputValue, setInputValue } = values || {};
+
+  const { inputValue, setInputValue, scoutbarReveal, setScoutbarReveal } =
+    values || {};
 
   /**
    * Revise action data type if its a function to a an array
-   * We want to give user the ability to Item creation fucntions as a parameter in the props
+   * We want to give user the ability to Item creation functions as a parameter in the props
    *
    * e.g
    * ...
@@ -55,6 +59,8 @@ const ScoutBarProvider: React.FC<ScoutBarProviderProps> = ({
         actions: currentAction,
         setAction,
         inputValue,
+        setScoutbarReveal,
+        scoutbarReveal,
         setInputValue: async (value: string) => {
           await setInputValue?.(value);
           searchItem(value);

--- a/src/components/stem/index.tsx
+++ b/src/components/stem/index.tsx
@@ -14,6 +14,7 @@ import React, {
 
 /* -------------------------- Internal Dependencies ------------------------- */
 import { classNames, isEmpty } from 'utils';
+import { ActionOptions } from 'index';
 import ScoutBarContext from 'helpers/context';
 import {
   IScoutAction,
@@ -21,7 +22,7 @@ import {
   ScoutBarProps,
   useScoutShortcut,
   useLocalStorage,
-  useKeybaordNavigation,
+  useKeyboardNavigation,
   IScoutStems,
   IScoutStem,
 } from 'index';
@@ -45,7 +46,7 @@ const ScoutBarStem = ({
     []
   );
   const ref = useRef<HTMLDivElement | null>(null);
-  const [cursor, setHovered, allCellElements] = useKeybaordNavigation(ref);
+  const [cursor, setHovered, allCellElements] = useKeyboardNavigation(ref);
 
   const { currentSection, setInputValue } = useContext(ScoutBarContext);
 
@@ -171,7 +172,8 @@ const ScoutbarStemCell: React.FC<{
   ({ item, active, setHovered, allCellElements, scrollStemSection }) => {
     const isNewPage =
       item.type === 'scout-section-page' && item?.children?.length > 0;
-    const { setCurrentSection } = useContext(ScoutBarContext);
+    const { setCurrentSection, setScoutbarReveal } =
+      useContext(ScoutBarContext);
 
     const ref = useRef(null);
     const elementActive =
@@ -190,19 +192,25 @@ const ScoutbarStemCell: React.FC<{
       [scrollStemSection]
     );
 
-    const handleClick: React.MouseEventHandler<
-      HTMLButtonElement | HTMLAnchorElement
-    > = useCallback(e => {
-      if (isNewPage) return setSection(item);
+    const options: ActionOptions = {
+      close: setScoutbarReveal,
+      // ...
+    };
 
-      item.action?.call(e);
-    }, []);
+    const handleClick = useCallback(
+      (e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+        if (isNewPage) return setSection(item);
+
+        item.action?.call(null, e, options);
+      },
+      []
+    );
 
     const handleShortcutAction: React.MouseEventHandler<
       HTMLButtonElement | HTMLAnchorElement
     > = useCallback(e => {
       /**
-       * Make the element active has a click event that matches expected behaviour
+       * Make the element active has a click event that matches expected behavior
        */
 
       if (isNewPage) return setSection(item);
@@ -210,7 +218,7 @@ const ScoutbarStemCell: React.FC<{
       if (item.href && item?.target)
         return window.open(item?.href, item?.target);
 
-      item.action?.call(e);
+      item.action?.call(null, e, options);
     }, []);
 
     const keyboardShortcut =

--- a/src/helpers/action-helpers.ts
+++ b/src/helpers/action-helpers.ts
@@ -1,12 +1,20 @@
 /* --------------------------- Internal Dependency -------------------------- */
+import React from 'react';
 import { guidGenerator } from 'utils';
+
+export interface ActionOptions {
+  close?: (val: boolean) => void;
+}
 
 export interface IScoutAction {
   id?: string;
   label: string;
   type?: 'scout-action';
   href?: string;
-  action?: () => void;
+  action?: (
+    e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+    options: ActionOptions
+  ) => void;
   target?: string;
   rel?: string;
   keyboardShortcut?: string[];

--- a/src/helpers/context.ts
+++ b/src/helpers/context.ts
@@ -10,6 +10,8 @@ interface IScoutContext {
   actions?: IScoutStems;
   setAction?: React.Dispatch<React.SetStateAction<IScoutStems>>;
   inputValue?: string;
+  setScoutbarReveal?: (value: boolean) => void;
+  scoutbarReveal?: boolean;
   setInputValue?: (value: string) => void;
   currentSection?: IScoutSectionAction | null;
   setCurrentSection?: (section: IScoutSectionAction | null) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export { default as ScoutBar } from './scoutbar';
  * but are exported and can be used by other applications.
  */
 export { default as useTrapFocus } from './helpers/use-trap-focus';
-export { default as useKeybaordNavigation } from './helpers/use-keyboard-navigation';
+export { default as useKeyboardNavigation } from './helpers/use-keyboard-navigation';
 export { default as useIsMounted } from './helpers/use-is-mounted';
 export { default as useLocalStorage } from './helpers/use-local-storage';
 export { default as useOnClickOutside } from './helpers/use-click-outside';

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -1,9 +1,9 @@
 /**
  * Scoutbar.js
  * @remarks
- * This test enviroment uses
+ * This test environment uses
  *  https://caniuse.com/import-maps so make sure you are on
- *  an enviroment that supports this
+ *  an environment that supports this
  * @author adenekan41
  */
 
@@ -31,7 +31,7 @@ ReactDOM.render(
         children: [
           createScoutAction({
             label: 'Page One',
-            action: () => alert('Page One'),
+            action: (e, { close }) => close?.(false),
           }),
           createScoutAction({
             label: 'Page Two',


### PR DESCRIPTION
### Description

#### Add callback to action fn to close scoutbar
Currently, you can close and reopen the Scoutbar with a stale state using the revealScoutbar prop, but in addition to that, we'd need a way to programmatically add this to actions to make it more seamless overall. Added 

```js
// Add callback to action fn to close scoutbar
// ....
      createScoutAction({
          label: 'Page One',
          action: (e, { close }) => close(false),
      })     
```
#### Shortcut doesnt work well on windows 
Fix, is to shift the SCA (shortcut action) from the windows button to the control button so we can trigger this with

`ctrl + k`

### Issues
- Fixes #11 
- Fixes #10 

### Authors Note
- N/A