### PR TITLE
Allow React.ReactElement type as icon

### DIFF
--- a/src/helpers/action-helpers.ts
+++ b/src/helpers/action-helpers.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 /* --------------------------- Internal Dependency -------------------------- */
 import { guidGenerator } from 'utils';
 

--- a/src/helpers/action-helpers.ts
+++ b/src/helpers/action-helpers.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 /* --------------------------- Internal Dependency -------------------------- */
 import { guidGenerator } from 'utils';
 
@@ -19,7 +20,7 @@ export interface IScoutAction {
   rel?: string;
   keyboardShortcut?: string[];
   disableIdledAction?: boolean;
-  icon?: HTMLElement | string;
+  icon?: React.ReactElement | HTMLElement | string;
   description?: string;
   ariaLabel?: string;
 }


### PR DESCRIPTION
Hey @adenekan41 I have run into a Typescript error when trying to use an element from a component library as an icon.

To resolve this I have added a union of `React.ReactElement` as a possible type to the definition of `icon` in `IScoutAction`, this will allow for React components to be used as icons in actions.

