### PR TITLE
Handle key property not being set on event in some circumstances

### DIFF
--- a/src/use-scout-shortcut.ts
+++ b/src/use-scout-shortcut.ts
@@ -89,7 +89,7 @@ const useScoutShortcut = (
   const handler = useCallback(
     (event: KeyboardEvent, key: string, position) => {
       const overrideKeyForOption =
-        !ROOT_KEY_MAPS.includes(event.key.toLowerCase()) &&
+        !ROOT_KEY_MAPS.includes(event.key?.toLowerCase()) &&
         ignoreStrokes((event.target as HTMLElement).tagName);
       /** Check If the key is already pressed, do nothing */
       if (event.repeat) return;


### PR DESCRIPTION
When an input is auto completed by chrome (e.g password/username) it triggers an event that scoutbar is listenting to but excludes the "key" property. This throws an exception when calling toLowerCase on undefined